### PR TITLE
new SHA for GHC tarball

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -476,7 +476,7 @@ in {
                 src-spec = rec {
                     version = "8.10.6";
                     url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "1s8cc50whb0qsgnmq6p40ir5yzp3nm3x0as9q518nh1klmrbmbs3";
+                    sha256 = "00ccsqm4hrb1ffqxib8c69wyj11b1f71yhhhkkhj57cnahfxp7ii";
                 };
 
                 ghc-patches = ghc-patches "8.10.6";


### PR DESCRIPTION
I may have provided the incorrect SHA for the GHC tarball.

The current SHA was acquired with
`nix-prefetch-url https://downloads.haskell.org/~ghc/8.10.6/ghc-8.10.6-src.tar.xz`

The SHA in this PR was acquired with
`nix-prefetch-url https://downloads.haskell.org/~ghc/8.10.6/ghc-8.10.6-src.tar.xz --unpack`

`nix-build` and `nix-shell --pure` succeed for both SHAs. I don't know if this new SHA will fix the CI issues in https://github.com/input-output-hk/haskell.nix/pull/1214